### PR TITLE
Fix: cleanup gatsby node query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -55,24 +55,7 @@ exports.createPages = async ({ graphql, actions }, themeOptions) => {
               filter: $filter
               sort: { publishedAt: desc }
             ) {
-              teaser
               slug
-              title
-              content
-              publishedAt
-              updatedAt
-              image(auto: [compress, format]) {
-                url
-              }
-              imagePostList: image(
-                w: 400
-                h: 220
-                fit: crop
-                crop: center
-                auto: [compress, format]
-              ) {
-                url
-              }
             }
           }
         }


### PR DESCRIPTION
Remove unnecessary code on `gatsby-node.js`

Full query have to be execute in page's templates
